### PR TITLE
Update Dockerfile

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -23,4 +23,4 @@ RUN npm run build
 EXPOSE 8080
 
 # Start the server
-CMD ["serve", "-s", "dist", "-l", "8080"]
+CMD serve -s dist -l ${PORT:-8080}


### PR DESCRIPTION
Replaced 
CMD ["serve", "-s", "dist", "-l", "8080"]
with 
CMD serve -s dist -l ${PORT:-8080}
This change tells the container to listen on the port provided by Cloud Run's $PORT variable. If that variable isn't set it will default to 8080.